### PR TITLE
Imperas found a bug with the Fence.I instruction. If a fence.i direct…

### DIFF
--- a/pipelined/src/ifu/ifu.sv
+++ b/pipelined/src/ifu/ifu.sv
@@ -40,7 +40,7 @@ module ifu (
 (* mark_debug = "true" *) output logic [2:0]  IFUHSIZE,
 (* mark_debug = "true" *) output logic  IFUHWRITE,
 (* mark_debug = "true" *) input logic   IFUHREADY,
-	(* mark_debug = "true" *) output logic [`XLEN-1:0] PCF, 
+	(* mark_debug = "true" *) output logic [`XLEN-1:0] PCFSpill, 
 	// Execute
 	output logic [`XLEN-1:0] 	PCLinkE,
 	input logic 				PCSrcE, 
@@ -103,7 +103,7 @@ module ifu (
 
   logic 					   CacheableF;
   logic [`XLEN-1:0]			   PCNextFSpill;
-  logic [`XLEN-1:0] 		   PCFSpill;
+  logic [`XLEN-1:0] 		   PCF;
   logic 					   SelNextSpillF;
   logic 					   ICacheFetchLine;
   logic 					   BusStall;

--- a/pipelined/src/lsu/lsu.sv
+++ b/pipelined/src/lsu/lsu.sv
@@ -79,7 +79,7 @@ module lsu (
    input  logic [`XLEN-1:0] SATP_REGW,                               // SATP (supervisor address translation and protection) CSR
    input  logic             STATUS_MXR, STATUS_SUM, STATUS_MPRV,     // STATUS CSR bits: make executable readable, supervisor user memory, machine privilege
    input  logic [1:0]       STATUS_MPP,                              // Machine previous privilege mode
-   input  logic [`XLEN-1:0] PCF,                                     // Fetch PC 
+   input  logic [`XLEN-1:0] PCFSpill,                                     // Fetch PC 
    input  logic             ITLBMissF,                               // ITLB miss causes HPTW (hardware pagetable walker) walk
    input  logic             InstrDAPageFaultF,                       // ITLB hit needs to update dirty or access bits
    output logic [`XLEN-1:0] PTE,                                     // Page table entry write to ITLB
@@ -152,7 +152,7 @@ module lsu (
   if(`VIRTMEM_SUPPORTED) begin : VIRTMEM_SUPPORTED
     hptw hptw(.clk, .reset, .MemRWM, .AtomicM, .ITLBMissF, .ITLBWriteF,
       .DTLBMissM, .DTLBWriteM, .InstrDAPageFaultF, .DataDAPageFaultM,
-      .FlushW, .DCacheStallW, .SATP_REGW, .PCF,
+      .FlushW, .DCacheStallW, .SATP_REGW, .PCFSpill,
       .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_MPP, .PrivilegeModeW,
       .ReadDataM(ReadDataM[`XLEN-1:0]), // ReadDataM is LLEN, but HPTW only needs XLEN
       .WriteDataM, .Funct3M, .LSUFunct3M, .Funct7M, .LSUFunct7M,

--- a/pipelined/src/mmu/hptw.sv
+++ b/pipelined/src/mmu/hptw.sv
@@ -33,7 +33,7 @@
 module hptw (
 	input logic                 clk, reset,
    	input logic [`XLEN-1:0]     SATP_REGW, // includes SATP.MODE to determine number of levels in page table
-	input logic [`XLEN-1:0]     PCF,  // addresses to translate
+	input logic [`XLEN-1:0]     PCFSpill,  // addresses to translate
  	input logic [`XLEN+1:0]     IEUAdrExtM, // addresses to translate
    	input logic [1:0]           MemRWM, AtomicM,
    	// system status
@@ -111,8 +111,8 @@ module hptw (
 	assign TLBMiss = (DTLBMissOrDAFaultM | ITLBMissOrDAFaultF);
 
 	// Determine which address to translate
-	mux2 #(`XLEN) vadrmux(PCF, IEUAdrExtM[`XLEN-1:0], DTLBWalk, TranslationVAdr);
-	//assign TranslationVAdr = DTLBWalk ? IEUAdrExtM[`XLEN-1:0] : PCF;
+	mux2 #(`XLEN) vadrmux(PCFSpill, IEUAdrExtM[`XLEN-1:0], DTLBWalk, TranslationVAdr);
+	//assign TranslationVAdr = DTLBWalk ? IEUAdrExtM[`XLEN-1:0] : PCFSpill;
 	assign CurrentPPN = PTE[`PPN_BITS+9:10];
 
 	// State flops

--- a/pipelined/src/wally/wallypipelinedcore.sv
+++ b/pipelined/src/wally/wallypipelinedcore.sv
@@ -61,7 +61,7 @@ module wallypipelinedcore (
   logic [2:0]             Funct3E;
   logic [31:0]             InstrD;
   (* mark_debug = "true" *) logic [31:0]             InstrM;
-  logic [`XLEN-1:0]         PCF, PCE, PCLinkE;
+  logic [`XLEN-1:0]         PCFSpill, PCE, PCLinkE;
   (* mark_debug = "true" *) logic [`XLEN-1:0]         PCM;
  logic [`XLEN-1:0]         CSRReadValW, MDUResultW;
    logic [`XLEN-1:0]         UnalignedPCNextF, PCNext2F;
@@ -167,7 +167,7 @@ module wallypipelinedcore (
     .StallF, .StallD, .StallE, .StallM, .StallW,
     .FlushD, .FlushE, .FlushM, .FlushW,
     // Fetch
-    .HRDATA, .PCF, .IFUHADDR, .PCNext2F,
+    .HRDATA, .PCFSpill, .IFUHADDR, .PCNext2F,
     .IFUStallF, .IFUHBURST, .IFUHTRANS, .IFUHSIZE,
           .IFUHREADY, .IFUHWRITE,
     .ICacheAccess, .ICacheMiss,
@@ -278,7 +278,7 @@ module wallypipelinedcore (
     .StoreAmoAccessFaultM,     // connects to privilege
     .InstrDAPageFaultF,
     
-    .PCF, .ITLBMissF, .PTE, .PageType, .ITLBWriteF, .SelHPTW,
+    .PCFSpill, .ITLBMissF, .PTE, .PageType, .ITLBWriteF, .SelHPTW,
     .LSUStallM);                     // change to LSUStallM
 
 

--- a/pipelined/testbench/common/functionName.sv
+++ b/pipelined/testbench/common/functionName.sv
@@ -48,7 +48,7 @@ module FunctionName(reset, clk, ProgramAddrMapFile, ProgramLabelMapFile);
   logic 	    StallD, StallE, FlushD, FlushE;
   integer 	    ProgramAddrIndex, ProgramAddrIndexQ;
 
-  assign PCF = testbench.dut.core.PCF;
+  assign PCF = testbench.dut.core.ifu.PCF;
   assign StallD = testbench.dut.core.StallD;
   assign StallE = testbench.dut.core.StallE;  
   assign FlushD = testbench.dut.core.FlushD;


### PR DESCRIPTION
…ly followed a store miss, the d$ would release Stall during the cache line write. Then transition to ReadHold.  This cause the d$ flush to go high while in ReadHold.  The solution is to ensure the cache continues to assert Stall while in WriteLine state.